### PR TITLE
perf: replace lodash's cloneDeep with fast-copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1344,6 +1344,11 @@
         }
       }
     },
+    "fast-copy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.1.tgz",
+      "integrity": "sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ=="
+    },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "compute-lcm": "^1.1.0",
+    "fast-copy": "^2.1.1",
     "json-schema-compare": "^0.2.2",
     "lodash": "^4.17.4"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-var cloneDeep = require('lodash/cloneDeep')
+var cloneDeep = require('fast-copy')
 var compact = require('lodash/compact')
 var compare = require('json-schema-compare')
 var computeLcm = require('compute-lcm')


### PR DESCRIPTION
As the title says.

Unfortunately the library currently relies heavily on deep cloning, which takes up the bulk of the run-time. 

This PR replaces the original deep-clone implementation (lodash'sh `cloneDeep`) with [`fast-copy`](https://github.com/planttheidea/fast-copy#isstrict). This tiny change alone makes JST run 20% faster on the stress test schema, which is fascinating. (And an indication of how inefficient this lib is.)