### PR TITLE
Clone schema just once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -386,7 +386,7 @@ var defaultResolvers = {
     return returnObject
   },
   oneOf(compacted, paths, mergeSchemas) {
-    var combinations = getAnyOfCombinations(cloneDeep(compacted))
+    var combinations = getAnyOfCombinations(compacted)
     var result = tryMergeSchemaGroups(combinations, mergeSchemas)
     var unique = uniqWith(result, compare)
 
@@ -452,8 +452,10 @@ function merger(rootSchema, options, totalSchemas) {
     $refResolver: default$RefResolver
   })
 
+  rootSchema = cloneDeep(rootSchema)
+
   function mergeSchemas(schemas, base, parents) {
-    schemas = cloneDeep(schemas.filter(notUndefined))
+    schemas = schemas.filter(notUndefined)
     parents = parents || []
     var merged = isPlainObject(base)
       ? base

--- a/test/specs/index.spec.js
+++ b/test/specs/index.spec.js
@@ -8,11 +8,14 @@ var expect = chai.expect
 var ajv = new Ajv()
 
 function merger(schema, options) {
+  var schemaClone = _.cloneDeep(schema)
   var result = mergerModule(schema, options)
   try {
     if (!ajv.validateSchema(result)) {
       throw new Error('Schema returned by resolver isn\'t valid.')
     }
+
+    expect(schema).to.eql(schemaClone)
     return result
   } catch (e) {
     if (!/stack/i.test(e.message)) {


### PR DESCRIPTION
Related to https://github.com/stoplightio/json-schema-merge-allof/pull/2 and sort of to https://github.com/stoplightio/json-schema-viewer/pull/109
We can still probably be more picky about cloning, but this is already something.
