### PR TITLE
Avoid deep cloning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1344,11 +1344,6 @@
         }
       }
     },
-    "fast-copy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.1.tgz",
-      "integrity": "sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ=="
-    },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "compute-lcm": "^1.1.0",
-    "fast-copy": "^2.1.1",
     "json-schema-compare": "^0.2.2",
     "lodash": "^4.17.4"
   }

--- a/test/specs/index.spec.js
+++ b/test/specs/index.spec.js
@@ -1,3 +1,4 @@
+'use strict'
 var chai = require('chai')
 var mergerModule = require('../../src')
 var Ajv = require('ajv')
@@ -14,14 +15,14 @@ function merger(schema, options) {
     if (!ajv.validateSchema(result)) {
       throw new Error('Schema returned by resolver isn\'t valid.')
     }
-
-    expect(schema).to.eql(schemaClone)
-    return result
   } catch (e) {
     if (!/stack/i.test(e.message)) {
       throw e
     }
   }
+
+  expect(schema).to.deep.eql(schemaClone)
+  return result
 }
 
 describe('module', function() {

--- a/test/specs/items.spec.js
+++ b/test/specs/items.spec.js
@@ -1,6 +1,14 @@
+'use strict'
 var chai = require('chai')
-var merger = require('../../src')
+var mergerModule = require('../../src')
 var expect = chai.expect
+
+function merger(schema, options) {
+  var schemaClone = JSON.parse(JSON.stringify(schema))
+  var result = mergerModule(schema, options)
+  expect(schema).to.deep.eql(schemaClone)
+  return result
+}
 
 describe('items', function() {
   it('merges additionalItems', function() {

--- a/test/specs/options.spec.js
+++ b/test/specs/options.spec.js
@@ -1,7 +1,13 @@
 var chai = require('chai')
-var merger = require('../../src')
-
+var mergerModule = require('../../src')
 var expect = chai.expect
+
+function merger(schema, options) {
+  var schemaClone = JSON.parse(JSON.stringify(schema))
+  var result = mergerModule(schema, options)
+  expect(schema).to.deep.eql(schemaClone)
+  return result
+}
 
 describe('options', function() {
   it('allows otherwise incompatible properties if option ignoreAdditionalProperties is true', function() {

--- a/test/specs/properties.spec.js
+++ b/test/specs/properties.spec.js
@@ -1,9 +1,16 @@
 var chai = require('chai')
-var merger = require('../../src')
 var sinon = require('sinon')
 var _ = require('lodash')
 var expect = chai.expect
 var Ajv = require('ajv')
+var mergerModule = require('../../src')
+
+function merger(schema, options) {
+  var schemaClone = JSON.parse(JSON.stringify(schema))
+  var result = mergerModule(schema, options)
+  expect(schema).to.deep.eql(schemaClone)
+  return result
+}
 
 var ajv = new Ajv()
 describe('properties', function() {


### PR DESCRIPTION
This should close the loop on cloning journey.

Executing 

```js
for (const schema of schemas) {
  const tree = new SchemaTree(schema, { mergeAllOf: true });
  tree.populate();
}
```

on all files located under
`@stoplight/json-schema-tree/src/__tests__/tree.spec.ts `and PNR Model yields

| this PR             | 0.7.4               | 0.7.3             | 0.7.2               |
|---------------------|---------------------|-------------------|---------------------|
| ~148.82689519980923 | ~181.34451360004022 | ~202.829233400058 | ~222.07805839991198 |


and we no longer have to rely on a dependency

```yaml
# this PR
143.71122499974445
142.05347499996424
141.74028899986297
159.0402519996278
157.58923499984667

# 0.7.4
173.24297099979594
182.42507100012153
188.9755029999651
195.5236820001155
166.55534100020304

# 0.7.3
215.48585900012404
195.63158199982718
204.95247300015762
219.03855200018734
179.03770099999383

# 0.7.2
225.95048899995163
232.9289549998939
228.85032099997625
209.42815299984068
213.2323739998974
```