### PR TITLE
fix: override description and summary values if ref siblings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -163,6 +163,26 @@ function cleanupReturnValue(returnObject) {
   return returnObject
 }
 
+function applyOverrides(originalValue, newValue) {
+  if (
+    isPlainObject(newValue) &&
+    isPlainObject(originalValue) &&
+    ('summary' in originalValue || 'description' in originalValue)
+  ) {
+    return {
+      ...newValue,
+      ...('description' in originalValue
+        ? { description: originalValue.description }
+        : null),
+      ...('summary' in originalValue
+        ? { summary: originalValue.summary }
+        : null)
+    }
+  }
+
+  return newValue
+}
+
 function createRequiredSubMerger(mergeSchemas, key, parents) {
   return function(schemas, subKey) {
     if (subKey === undefined) {
@@ -501,7 +521,10 @@ function merger(rootSchema, options, totalSchemas) {
     // there are no false and we don't need the true ones as they accept everything
     schemas = schemas.filter(isPlainObject)
 
-    schemas = schemas.map(schema => '$ref' in schema ? options.$refResolver(schema.$ref) : Object.assign({}, schema))
+    schemas = schemas.map(schema => '$ref' in schema ? applyOverrides(
+      schema,
+      options.$refResolver(schema.$ref)
+    ) : Object.assign({}, schema))
 
     var types = schemas.map(schema => inferType(schema)).filter(notUndefined)
 

--- a/test/specs/resolveAllOf.spec.js
+++ b/test/specs/resolveAllOf.spec.js
@@ -1,0 +1,69 @@
+'use strict'
+
+var chai = require('chai')
+var resolveAllOf = require('../../src/index')
+var expect = chai.expect
+
+describe('resolveAllOf', function () {
+  it('with refereces and description siblings', function () {
+    const fragment = {
+      allOf: [
+        { $ref: '#/properties/AAAAA/allOf/0', description: 'BBBBB' },
+        { examples: ['BBBBB'] }
+      ]
+    }
+    const result = resolveAllOf(fragment, {
+      deep: false,
+      resolvers: resolveAllOf.stoplightResolvers,
+      $refResolver() {
+        return { description: 'AAAAA', type: 'string' }
+      }
+    })
+    expect(result).to.eql({
+      type: 'string',
+      description: 'BBBBB',
+      examples: ['BBBBB']
+    })
+  })
+  it('with refereces and summary siblings', function () {
+    const fragment = {
+      allOf: [
+        { $ref: '#/properties/AAAAA/allOf/0', summary: 'BBBBB is used for payment processing' },
+        { examples: ['BBBBB'] }
+      ]
+    }
+    const result = resolveAllOf(fragment, {
+      deep: false,
+      resolvers: resolveAllOf.stoplightResolvers,
+      $refResolver() {
+        return { summary: 'AAAAA is used for puppy adoption', type: 'string' }
+      }
+    })
+    expect(result).to.eql({
+      type: 'string',
+      summary: 'BBBBB is used for payment processing',
+      examples: ['BBBBB']
+    })
+  })
+  it('with refereces and no siblings', function () {
+    const fragment = {
+      allOf: [
+        { $ref: '#/properties/AAAAA/allOf/0' },
+        { examples: ['BBBBB'] }
+      ]
+    }
+    const result = resolveAllOf(fragment, {
+      deep: false,
+      resolvers: resolveAllOf.stoplightResolvers,
+      $refResolver() {
+        return { description: 'AAAAA', summary: 'AAAAA is used for puppy adoption', type: 'string' }
+      }
+    })
+    expect(result).to.eql({
+      type: 'string',
+      description: 'AAAAA',
+      summary: 'AAAAA is used for puppy adoption',
+      examples: ['BBBBB']
+    })
+  })
+})


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/stoplightio/elements/issues/2419

When using allOf, the description and summary reference siblings get overridden by the reference if it exists in the reference as well. This deviates from how we are resolving refs in stoplight/json and a few other places. 

## Description
<!-- Describe your technical changes in detail. -->
Used the same applyOverrides code from @stoplight/json - the only difference is this one uses lodash's `isPlainObject`. I didn't want to import the full lib for that one function, but I am open to doing that if that is preferred
 
Call applyOverrides when the schema's reference is returned to ensure it resolves as expected

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
Added automated test to cover:

-  when description and summary are reference siblings

- When there are no reference siblings to ensure values are still kept from the reference

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
